### PR TITLE
Get rid of the wrapping div. Fix #15

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,15 +51,17 @@ export function compose(fn, L1, E1) {
       render() {
         const error = this._getError();
         const loading = this._isLoading();
+        
+        if (!! error) {
+          return ( <ErrorComponent error={error}/> );
+        }
+        
+        if (!! loading) {
+          return ( <LoadingComponent /> );
+        }
+        
+        return ( <ChildComponent {...this._getProps()} /> );
 
-        return (
-          <div>
-            {error ? <ErrorComponent error={error}/> : null }
-            {(!error && loading) ? <LoadingComponent /> : null}
-            {(!error && !loading) ?
-              <ChildComponent {...this._getProps()} /> : null}
-          </div>
-        );
       }
 
       _subscribe(props) {


### PR DESCRIPTION
The `div` that wraps around the child component creates an inconsistency of styling of wrapped and unwrapped component. This file change will resolve this issue.