### PR TITLE
Fix for improper loading state in redux example

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ setInterval(() => {
 const Time = ({time}) => (<div><b>Time is</b>: {time}</div>);
 
 const onPropsChange = (props, onData) => {
+  onData(null, {time: store.getState().time});
   return store.subscribe(() => {
     const {time} = store.getState();
     onData(null, {time})


### PR DESCRIPTION
When using store.subscribe() no data is provided until the store state changes at least once. This leaves the component in a loading state until something changes the store state for the first time. To fix this, you can get the current state once on initial run. This isn't apparent in the example because the state is changed very early, but in a real app you may be waiting a long time for the first state change.