### PR TITLE
Updated compose to allow passing of context into the subscribe function.

### DIFF
--- a/lib/__tests__/compose.js
+++ b/lib/__tests__/compose.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { compose } from '../';
 import { shallow } from 'enzyme';
-import React from 'react';
+import React, { PropTypes } from 'react';
 const { describe, it } = global;
 
 describe('compose', () => {
@@ -26,6 +26,20 @@ describe('compose', () => {
       Comp.nice = 100;
       const Container = compose(() => {})(Comp);
       expect(Container.nice).to.equal(100);
+    });
+  });
+
+  describe('context', () => {
+    it('should pass the context into the subscribe call', () => {
+      const Comp = ({}) => (<p></p>);
+      const onPropsChange = (props, onData, context) => {
+        expect(context.c1).to.equal('test');
+        onData(null, {});
+      };
+      const Container = compose(onPropsChange, null, null, {
+        contextTypes: {c1: PropTypes.string}
+      })(Comp);
+      shallow(<Container/>, {context: {c1: 'test'}});
     });
   });
 

--- a/lib/__tests__/pure_components.js
+++ b/lib/__tests__/pure_components.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { compose } from '../';
 import { shallow } from 'enzyme';
-import React from 'react';
+import React, { PropTypes } from 'react';
 const { describe, it } = global;
 
 describe('shouldComponentUpdate', () => {
@@ -37,7 +37,35 @@ describe('shouldComponentUpdate', () => {
         const Container = compose(() => null)(Comp);
         const i = shallow(<Container p1="10"/>).instance();
 
-        expect(i.shouldComponentUpdate({p1: '10'}, {})).to.be.equal(false);
+        expect(i.shouldComponentUpdate({p1: '10'}, {}, {})).to.be.equal(false);
+      });
+    });
+
+    describe('with context', () => {
+      it('should be true if context are different', () => {
+        const Container = compose(() => null, null, null, {
+          pure: true,
+          contextTypes: {c1: PropTypes.string}
+        })(Comp);
+
+        const i = shallow(<Container/>, {context: {c1: '123'}}).instance();
+
+        expect(i.shouldComponentUpdate({}, {}, {c1: '456'}))
+          .to.be.equal(true);
+        i.context = {c1: '456'}
+
+        expect(i.shouldComponentUpdate({}, {}, {c1: '456', c2: '123'}))
+          .to.be.equal(true);
+      });
+
+      it('should be false if context are the same', () => {
+        const Container = compose(() => null, null, null, {
+          pure: true,
+          contextTypes: {c1: PropTypes.string}
+        })(Comp);
+        const i = shallow(<Container/>, {context: {c1: '123'}}).instance();
+
+        expect(i.shouldComponentUpdate({}, {}, {c1: '123'})).to.be.equal(false);
       });
     });
 
@@ -63,7 +91,8 @@ describe('shouldComponentUpdate', () => {
         expect(i.shouldComponentUpdate(i.props, {error})).to.be.equal(true);
         i.state = {error};
 
-        expect(i.shouldComponentUpdate(i.props, {error})).to.be.equal(false);
+        expect(i.shouldComponentUpdate(i.props, {error}, {}))
+          .to.be.equal(false);
       });
     });
 
@@ -77,7 +106,7 @@ describe('shouldComponentUpdate', () => {
         i.state = {payload};
 
         const samePayload = {aa: 10};
-        expect(i.shouldComponentUpdate(i.props, {payload: samePayload}))
+        expect(i.shouldComponentUpdate(i.props, {payload: samePayload}, {}))
           .to.be.equal(false);
       });
 
@@ -90,7 +119,7 @@ describe('shouldComponentUpdate', () => {
         i.state = {payload};
 
         const samePayload = {aa: 10};
-        expect(i.shouldComponentUpdate(i.props, {payload: samePayload}))
+        expect(i.shouldComponentUpdate(i.props, {payload: samePayload}, {}))
           .to.be.equal(false);
       });
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ export function DefaultLoadingComponent() {
   return (<p>Loading...</p>);
 }
 
-export function compose(fn, L1, E1, options = {pure: true}) {
+export function compose(fn, L1, E1, {pure = true, contextTypes} = {}) {
   return (ChildComponent, L2, E2) => {
     invariant(
       Boolean(ChildComponent),
@@ -35,15 +35,15 @@ export function compose(fn, L1, E1, options = {pure: true}) {
         // XXX: In the server side environment, we need to
         // stop the subscription right away. Otherwise, it's a starting
         // point to huge subscription leak.
-        this._subscribe(props);
+        this._subscribe(props, context);
       }
 
       componentDidMount() {
         this._mounted = true;
       }
 
-      componentWillReceiveProps(props) {
-        this._subscribe(props);
+      componentWillReceiveProps(props, context) {
+        this._subscribe(props, context);
       }
 
       componentWillUnmount() {
@@ -51,13 +51,14 @@ export function compose(fn, L1, E1, options = {pure: true}) {
         this._unsubscribe();
       }
 
-      shouldComponentUpdate(nextProps, nextState) {
-        if (!options.pure) {
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        if (!pure) {
           return true;
         }
 
         return (
           !shallowEqual(this.props, nextProps) ||
+          !shallowEqual(this.context, nextContext) ||
           this.state.error !== nextState.error ||
           !shallowEqual(this.state.payload, nextState.payload)
         );
@@ -78,10 +79,10 @@ export function compose(fn, L1, E1, options = {pure: true}) {
         return (<ChildComponent {...this._getProps()} />);
       }
 
-      _subscribe(props) {
+      _subscribe(props, context) {
         this._unsubscribe();
 
-        this._stop = fn(props, (error, payload) => {
+        const onData = (error, payload) => {
           if (error) {
             invariant(
               error.message && error.stack,
@@ -96,7 +97,9 @@ export function compose(fn, L1, E1, options = {pure: true}) {
           } else {
             this.state = state;
           }
-        });
+        };
+
+        this._stop = fn(props, onData, context);
       }
 
       _unsubscribe() {
@@ -138,15 +141,16 @@ export function compose(fn, L1, E1, options = {pure: true}) {
       'ChildComponent';
 
     Container.displayName = `Container(${childDisplayName})`;
+    Container.contextTypes = contextTypes;
     return hoistStatics(Container, ChildComponent);
   };
 }
 
 export function composeWithTracker(reactiveFn, L, E, options) {
-  const onPropsChange = (props, onData) => {
+  const onPropsChange = (props, onData, context) => {
     let trackerCleanup;
     const handler = Tracker.autorun(() => {
-      trackerCleanup = reactiveFn(props, onData);
+      trackerCleanup = reactiveFn(props, onData, context);
     });
 
     return () => {
@@ -161,8 +165,8 @@ export function composeWithTracker(reactiveFn, L, E, options) {
 }
 
 export function composeWithPromise(fn, L, E, options) {
-  const onPropsChange = (props, onData) => {
-    const promise = fn(props);
+  const onPropsChange = (props, onData, context) => {
+    const promise = fn(props, context);
     invariant(
       (typeof promise.then === 'function') &&
       (typeof promise.catch === 'function'),


### PR DESCRIPTION
Added a new option called 'contextTypes' that sets the contextTypes for the container.

The context is then passed in to the subscribe call.

Fixes #45 