### PR TITLE
composeWithTracker - wrap the Tracker.autorun with Tracker.nonreactive

### DIFF
--- a/lib/__tests__/compose_with_tracker.js
+++ b/lib/__tests__/compose_with_tracker.js
@@ -10,6 +10,9 @@ describe('composeWithTracker', () => {
       autorun: fn => {
         fn();
         return {stop: () => {}};
+      },
+      nonreactive: fn => {
+        return fn();
       }
     };
     const Comp = class extends React.Component {
@@ -34,6 +37,9 @@ describe('composeWithTracker', () => {
         fn();
         runAgain = fn;
         return {stop: () => {}};
+      },
+      nonreactive: fn => {
+        return fn();
       }
     };
 
@@ -57,6 +63,9 @@ describe('composeWithTracker', () => {
       autorun: fn => {
         fn();
         return {stop: done};
+      },
+      nonreactive: fn => {
+        return fn();
       }
     };
     const Comp = ({name}) => (<div>{name}</div>);
@@ -73,6 +82,9 @@ describe('composeWithTracker', () => {
       autorun: fn => {
         fn();
         return {stop: () => null};
+      },
+      nonreactive: fn => {
+        return fn();
       }
     };
     const Comp = ({name}) => (<div>{name}</div>);
@@ -90,6 +102,9 @@ describe('composeWithTracker', () => {
       autorun: fn => {
         fn();
         return {stop: () => {}};
+      },
+      nonreactive: fn => {
+        return fn();
       }
     };
     const Comp = ({name}) => (<div>{name}</div>);

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,8 +145,10 @@ export function compose(fn, L1, E1, options = {pure: true}) {
 export function composeWithTracker(reactiveFn, L, E, options) {
   const onPropsChange = (props, onData) => {
     let trackerCleanup;
-    const handler = Tracker.autorun(() => {
-      trackerCleanup = reactiveFn(props, onData);
+    const handler = Tracker.nonreactive(() => {
+      return Tracker.autorun(() => {
+        trackerCleanup = reactiveFn(props, onData);
+      });
     });
 
     return () => {


### PR DESCRIPTION
This ensures that outside computations do not cause issues with the current component.

Fixes #33