### PR TITLE
undo "fix typo"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "npm run lint && npm run testonly",
     "test-watch": "npm run testonly -- --watch"
   },
-  "browser": "./dist/browser.js",
+  "browser": ".dist/browser.js",
   "react-native": "./dist/index.js",
   "devDependencies": {
     "nodemon": "1.7.x",


### PR DESCRIPTION
This change causes errors like this (tried on meteor 1.3 beta 12):

```
index.jsx:142Uncaught TypeError: (0 , _reactKomposer.composeWithTracker) is not a function
```