### PR TITLE
send props to errorHandler and loadingHandler

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -106,18 +106,18 @@ export default function compose(dataLoader, options = {}) {
         const props = this.props;
         const { data, error } = this.state;
 
-        if (error) {
-          return errorHandler(error);
-        }
-
-        if (!data) {
-          return loadingHandler();
-        }
-
         const finalProps = {
           ...props,
           ...data,
         };
+        
+        if (error) {
+          return errorHandler(error, finalProps);
+        }
+
+        if (!data) {
+          return loadingHandler(finalProps);
+        }
 
         const setChildRef = (c) => {
           this.child = c;


### PR DESCRIPTION
I have a scenario where a parent component sends a prop down to be consumed by my container.
In the cases in that `errorHandler` is rendered, though, I also need to consume the same prop and it is not available.

The prop in question is used by the inner component to define its [order](https://developer.mozilla.org/en/docs/Web/CSS/order) value. Without the `order` value, the error component is totally misplaced.

---

Example:

```html
<Blog>
  <Article id="1" order={3} />
  <Article id="2" order={1} />
  <Article id="3" order={2} />
</Blog>
```

If `Article#3` fails and I cannot define `order` for its `errorHandler`, then it would be rendered on top, instead of the middle:

```html
<div class="Blog">
  <div class="Article" id="1" style="order: 3" />
  <div class="Article" id="2" style="order: 1" />
  <div class="Article-error" /> <!-- doesn't contain `order` statement -->
                                <!-- will render on top -->
</div>
```
