### PR TITLE
Make refs optional

### DIFF
--- a/dist/compose.js
+++ b/dist/compose.js
@@ -42,7 +42,7 @@ var _lodash = require('lodash.pick');
 
 var _lodash2 = _interopRequireDefault(_lodash);
 
-var _reactStubber = require('react-stubber');
+var _reactStubber = require('@storybook/react-stubber');
 
 var _utils = require('./utils');
 

--- a/dist/compose.js
+++ b/dist/compose.js
@@ -49,27 +49,29 @@ var _utils = require('./utils');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function compose(dataLoader) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   return function (Child) {
-    var _options$errorHandler = options.errorHandler;
-    var errorHandler = _options$errorHandler === undefined ? function (err) {
+    var _options$errorHandler = options.errorHandler,
+        errorHandler = _options$errorHandler === undefined ? function (err) {
       throw err;
-    } : _options$errorHandler;
-    var _options$loadingHandl = options.loadingHandler;
-    var loadingHandler = _options$loadingHandl === undefined ? function () {
+    } : _options$errorHandler,
+        _options$loadingHandl = options.loadingHandler,
+        loadingHandler = _options$loadingHandl === undefined ? function () {
       return null;
-    } : _options$loadingHandl;
-    var _options$env = options.env;
-    var env = _options$env === undefined ? {} : _options$env;
-    var _options$pure = options.pure;
-    var pure = _options$pure === undefined ? false : _options$pure;
-    var _options$propsToWatch = options.propsToWatch;
-    var propsToWatch = _options$propsToWatch === undefined ? null : _options$propsToWatch;
-    var _options$shouldSubscr = options.shouldSubscribe;
-    var shouldSubscribe = _options$shouldSubscr === undefined ? null : _options$shouldSubscr;
-    var _options$shouldUpdate = options.shouldUpdate;
-    var shouldUpdate = _options$shouldUpdate === undefined ? null : _options$shouldUpdate;
+    } : _options$loadingHandl,
+        _options$env = options.env,
+        env = _options$env === undefined ? {} : _options$env,
+        _options$pure = options.pure,
+        pure = _options$pure === undefined ? false : _options$pure,
+        _options$propsToWatch = options.propsToWatch,
+        propsToWatch = _options$propsToWatch === undefined ? null : _options$propsToWatch,
+        _options$shouldSubscr = options.shouldSubscribe,
+        shouldSubscribe = _options$shouldSubscr === undefined ? null : _options$shouldSubscr,
+        _options$shouldUpdate = options.shouldUpdate,
+        shouldUpdate = _options$shouldUpdate === undefined ? null : _options$shouldUpdate,
+        _options$withRef = options.withRef,
+        withRef = _options$withRef === undefined ? true : _options$withRef;
 
     var Container = function (_React$Component) {
       (0, _inherits3.default)(Container, _React$Component);
@@ -147,7 +149,7 @@ function compose(dataLoader) {
 
           var onData = function onData(error, data) {
             if (_this2._unmounted) {
-              throw new Error('Tyring set data after component(' + Container.displayName + ') has unmounted.');
+              throw new Error('Trying to set data after component(' + Container.displayName + ') has unmounted.');
             }
 
             var payload = { error: error, data: data };
@@ -177,9 +179,9 @@ function compose(dataLoader) {
           var _this3 = this;
 
           var props = this.props;
-          var _state = this.state;
-          var data = _state.data;
-          var error = _state.error;
+          var _state = this.state,
+              data = _state.data,
+              error = _state.error;
 
 
           if (error) {
@@ -196,7 +198,7 @@ function compose(dataLoader) {
             _this3.child = c;
           };
 
-          return _react2.default.createElement(Child, (0, _extends3.default)({ ref: setChildRef }, finalProps));
+          return withRef ? _react2.default.createElement(Child, (0, _extends3.default)({ ref: setChildRef }, finalProps)) : _react2.default.createElement(Child, finalProps);
         }
       }]);
       return Container;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26,10 +26,10 @@ var stub = exports.stub = _reactStubber.stub;
 var compose = exports.compose = _compose3.default;
 
 function setDefaults() {
-  var mainOptions = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var mainOptions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
   return function (dataLoader) {
-    var otherOptions = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var otherOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     var options = (0, _extends3.default)({}, mainOptions, otherOptions);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,7 +12,7 @@ var _extends3 = _interopRequireDefault(_extends2);
 exports.setDefaults = setDefaults;
 exports.merge = merge;
 
-var _reactStubber = require('react-stubber');
+var _reactStubber = require('@storybook/react-stubber');
 
 var _compose2 = require('./compose');
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-komposer",
+  "name": "@storybook/react-komposer",
   "version": "2.0.0",
   "description": "Generic way to compose data containers for React.",
   "repository": {
@@ -39,7 +39,7 @@
     "jsdom": "^9.5.0"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
@@ -50,6 +50,6 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "npm": "^3.0.0"
+    "npm": ">=3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/react-komposer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Generic way to compose data containers for React.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Generic way to compose data containers for React.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadirahq/react-komposer.git"
+    "url": "https://github.com/storybooks/react-komposer/"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/react-komposer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Generic way to compose data containers for React.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/react-komposer",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Generic way to compose data containers for React.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-runtime": "^6.11.6",
     "hoist-non-react-statics": "^1.2.0",
     "lodash.pick": "^4.4.0",
-    "react-stubber": "^1.0.0",
+    "@storybook/react-stubber": "^1.0.0",
     "shallowequal": "^0.2.2"
   },
   "main": "dist/index.js",

--- a/src/compose.js
+++ b/src/compose.js
@@ -14,6 +14,7 @@ export default function compose(dataLoader, options = {}) {
       propsToWatch = null, // Watch all the props.
       shouldSubscribe = null,
       shouldUpdate = null,
+      withRef = true,
     } = options;
 
     class Container extends React.Component {
@@ -123,9 +124,9 @@ export default function compose(dataLoader, options = {}) {
           this.child = c;
         };
 
-        return (
-          <Child ref={setChildRef} {...finalProps} />
-        );
+        return withRef
+          ? <Child ref={setChildRef} {...finalProps} />
+          : <Child {...finalProps} />;
       }
     }
 

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import shallowEqual from 'shallowequal';
 import pick from 'lodash.pick';
-import { mayBeStubbed } from 'react-stubber';
+import { mayBeStubbed } from '@storybook/react-stubber';
 import { inheritStatics } from './utils';
 
 export default function compose(dataLoader, options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 import {
   setStubbingMode as _setStubbingMode,
   stub as _stub,
-} from 'react-stubber';
+} from '@storybook/react-stubber';
 import _compose from './compose';
 
 export const setStubbingMode = _setStubbingMode;

--- a/src/tests/compose.js
+++ b/src/tests/compose.js
@@ -130,7 +130,7 @@ describe('compose', () => {
       el.instance().componentWillUnmount();
 
       const run = () => onData(null, { aa: 10 });
-      expect(run).to.throw(/Tyring set data after/);
+      expect(run).to.throw(/Trying to set data after/);
     });
   });
 

--- a/src/tests/compose.js
+++ b/src/tests/compose.js
@@ -71,12 +71,23 @@ describe('compose', () => {
       expect(el.html()).to.match(/Aiyo/);
     });
 
-    it('should set the child ref', () => {
+    it('should set the child ref by default', () => {
       const Container = compose((props, onData) => {
         onData(null, { name: 'arunoda' });
       })(Comp);
       const el = mount(<Container name="arunoda" />);
       expect(el.instance().child.props.name).to.be.equal('arunoda');
+    });
+
+    it("should't set the child ref if withRef is false", () => {
+      const options = {
+        withRef: false,
+      };
+      const Container = compose((props, onData) => {
+        onData(null, { name: 'arunoda' });
+      }, options)(Comp);
+      const el = mount(<Container name="arunoda" />);
+      expect(el.instance()).not.to.have.property('child');
     });
   });
 


### PR DESCRIPTION
React doesn't support refs for stateless functional components (SFCs), and starting from next major version, it will warn about it (see https://github.com/storybooks/storybook/issues/1539).

This PR makes it possible to opt out of setting child ref, so that `compose` can be used with SFCs.