### PR TITLE
Allow this repository to work with NPM 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "npm": "^3.0.0"
+    "npm": ">=3.0.0"
   }
 }


### PR DESCRIPTION
Currently installing this project with NPM 5 results in an "Unsupported engine" error. This allows later versions of NPM to use this project.