### PR TITLE
Fix a failing test

### DIFF
--- a/dist/compose.js
+++ b/dist/compose.js
@@ -49,27 +49,27 @@ var _utils = require('./utils');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function compose(dataLoader) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   return function (Child) {
-    var _options$errorHandler = options.errorHandler;
-    var errorHandler = _options$errorHandler === undefined ? function (err) {
+    var _options$errorHandler = options.errorHandler,
+        errorHandler = _options$errorHandler === undefined ? function (err) {
       throw err;
-    } : _options$errorHandler;
-    var _options$loadingHandl = options.loadingHandler;
-    var loadingHandler = _options$loadingHandl === undefined ? function () {
+    } : _options$errorHandler,
+        _options$loadingHandl = options.loadingHandler,
+        loadingHandler = _options$loadingHandl === undefined ? function () {
       return null;
-    } : _options$loadingHandl;
-    var _options$env = options.env;
-    var env = _options$env === undefined ? {} : _options$env;
-    var _options$pure = options.pure;
-    var pure = _options$pure === undefined ? false : _options$pure;
-    var _options$propsToWatch = options.propsToWatch;
-    var propsToWatch = _options$propsToWatch === undefined ? null : _options$propsToWatch;
-    var _options$shouldSubscr = options.shouldSubscribe;
-    var shouldSubscribe = _options$shouldSubscr === undefined ? null : _options$shouldSubscr;
-    var _options$shouldUpdate = options.shouldUpdate;
-    var shouldUpdate = _options$shouldUpdate === undefined ? null : _options$shouldUpdate;
+    } : _options$loadingHandl,
+        _options$env = options.env,
+        env = _options$env === undefined ? {} : _options$env,
+        _options$pure = options.pure,
+        pure = _options$pure === undefined ? false : _options$pure,
+        _options$propsToWatch = options.propsToWatch,
+        propsToWatch = _options$propsToWatch === undefined ? null : _options$propsToWatch,
+        _options$shouldSubscr = options.shouldSubscribe,
+        shouldSubscribe = _options$shouldSubscr === undefined ? null : _options$shouldSubscr,
+        _options$shouldUpdate = options.shouldUpdate,
+        shouldUpdate = _options$shouldUpdate === undefined ? null : _options$shouldUpdate;
 
     var Container = function (_React$Component) {
       (0, _inherits3.default)(Container, _React$Component);
@@ -147,7 +147,7 @@ function compose(dataLoader) {
 
           var onData = function onData(error, data) {
             if (_this2._unmounted) {
-              throw new Error('Tyring set data after component(' + Container.displayName + ') has unmounted.');
+              throw new Error('Trying to set data after component(' + Container.displayName + ') has unmounted.');
             }
 
             var payload = { error: error, data: data };
@@ -177,9 +177,9 @@ function compose(dataLoader) {
           var _this3 = this;
 
           var props = this.props;
-          var _state = this.state;
-          var data = _state.data;
-          var error = _state.error;
+          var _state = this.state,
+              data = _state.data,
+              error = _state.error;
 
 
           if (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -26,10 +26,10 @@ var stub = exports.stub = _reactStubber.stub;
 var compose = exports.compose = _compose3.default;
 
 function setDefaults() {
-  var mainOptions = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var mainOptions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
   return function (dataLoader) {
-    var otherOptions = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var otherOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     var options = (0, _extends3.default)({}, mainOptions, otherOptions);
 

--- a/src/tests/compose.js
+++ b/src/tests/compose.js
@@ -130,7 +130,7 @@ describe('compose', () => {
       el.instance().componentWillUnmount();
 
       const run = () => onData(null, { aa: 10 });
-      expect(run).to.throw(/Tyring set data after/);
+      expect(run).to.throw(/Trying to set data after/);
     });
   });
 


### PR DESCRIPTION
One test was failing because the "dist" version of the lib was not updated due to last change on a dataLoader error message. This PR updates the "dist" version to latest and fix the test failing.