### PR TITLE
Support subscribe predicates with all/watched props available

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -56,7 +56,7 @@ export default function compose(dataLoader, options = {}) {
 
       _shouldSubscribe(props) {
         const firstRun = !this._cachedWatchingProps;
-        const nextProps = pick(props, propsToWatch);
+        const nextProps = propsToWatch ? pick(props, propsToWatch) : props;
         const currentProps = this._cachedWatchingProps || {};
         this._cachedWatchingProps = nextProps;
 


### PR DESCRIPTION
This PR enables to define `shouldSubscribe` predicates with all (no `propToWatch` provided) and watched props. This is attempt to solve https://github.com/arunoda/react-komposer/issues/158 issue as well.