### PR TITLE
Pass container context to handle sending data on unmounted

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,9 +441,10 @@ const Container = compose(genPromiseLoader(somePromiseObject))(UIComponent);
 
 ```js
 function getReduxLoader(mapper) {
-    return (props, onData, env) => {
+    return (props, onData, env, container) => {
         // Accessing the reduxStore via the env.
         return env.reduxStore.subscribe((state) => {
+            if (container._unmounted) return;
             onData(null, mapper(state, env));
         });
     };
@@ -458,10 +459,11 @@ const Container = compose(getReduxLoader(myMapper))(UIComponent)
 
 ```js
 function getTrackerLoader(reactiveMapper) {
-  return (props, onData, env) => {
+  return (props, onData, env, container) => {
     let trackerCleanup = null;
     const handler = Tracker.nonreactive(() => {
       return Tracker.autorun(() => {
+        if (container._unmounted) return;
       	// assign the custom clean-up function.
         trackerCleanup = reactiveMapper(props, onData, env);
       });

--- a/src/compose.js
+++ b/src/compose.js
@@ -93,7 +93,7 @@ export default function compose(dataLoader, options = {}) {
 
         // We need to do this before subscribing again.
         this._unsubscribe();
-        this._stop = dataLoader(props, onData, env);
+        this._stop = dataLoader(props, onData, env, this);
       }
 
       _unsubscribe() {


### PR DESCRIPTION
This PR gives an option to avoid https://github.com/arunoda/react-komposer/issues/152 issue by passing the container context to check on the reactive computation if it was unmounted before to proceed sending data.