### PR TITLE
Implement ref as an option

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -14,6 +14,7 @@ export default function compose(dataLoader, options = {}) {
       propsToWatch = null, // Watch all the props.
       shouldSubscribe = null,
       shouldUpdate = null,
+      withRef = false,
     } = options;
 
     class Container extends React.Component {
@@ -119,12 +120,16 @@ export default function compose(dataLoader, options = {}) {
           ...data,
         };
 
-        const setChildRef = (c) => {
-          this.child = c;
-        };
+        const refs = {};
+        if (withRef) {
+          const setChildRef = (c) => {
+            this.child = c;
+          };
+          refs.ref = setChildRef;
+        }
 
         return (
-          <Child ref={setChildRef} {...finalProps} />
+          <Child {...refs} {...finalProps} />
         );
       }
     }

--- a/src/tests/compose.js
+++ b/src/tests/compose.js
@@ -72,9 +72,10 @@ describe('compose', () => {
     });
 
     it('should set the child ref', () => {
+      const options = { withRef: true };
       const Container = compose((props, onData) => {
         onData(null, { name: 'arunoda' });
-      })(Comp);
+      }, options)(Comp);
       const el = mount(<Container name="arunoda" />);
       expect(el.instance().child.props.name).to.be.equal('arunoda');
     });


### PR DESCRIPTION
This PR makes the ref created to the child component as an option. This will enable you to wrap by default stateless components with the compose function and avoid the warning produced on react 16 version (`Warning: Stateless function components cannot be given refs.`).

